### PR TITLE
Default to current_path unless release_path exists

### DIFF
--- a/lib/rvm/capistrano/base.rb
+++ b/lib/rvm/capistrano/base.rb
@@ -11,8 +11,8 @@ rvm_with_capistrano do
       when "release_path"
         shell = "rvm_path=#{rvm_path} #{shell} --path '#{release_path}'"
       when "latest_release"
-        latest_release_path = exists?(:deploy_timestamped) ? release_path : current_path
-        shell = "rvm_path=#{rvm_path} #{shell} --path '#{latest_release_path}'"
+        path = %Q{path="#{current_path}" && [[ -d #{release_path} ]] && path="#{release_path}"}
+        shell = "#{path} ; rvm_path=#{rvm_path} #{shell} --path $path"
       when "local"
         ruby = (ENV['GEM_HOME'] || "").gsub(/.*\//, "")
         raise "Failed to get ruby version from GEM_HOME. Please make sure rvm is loaded!" if ruby.empty?


### PR DESCRIPTION
This adds a little shell preamble to check if a release path exists. If it does, use that path for RVM. If not, use the current path. This ensures that both deploys and commands work. In the latter case there is no release path.

This _should_ help address https://vitals.atlassian.net/browse/DEV-226